### PR TITLE
Configure Maven to support Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.5.1</version>
         <configuration>
-          <source/>
-          <target/>
+          <source>8</source>
+          <target>8</target>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
With the default configuration Maven supports only Java 5 features.

In Eclipse, you have to invoke "Maven -> Update Project ..." from the Package Explorer context menu.
